### PR TITLE
Remove legacy connect/disconnect messages

### DIFF
--- a/src/adapters/shell_adapter/adapter.py
+++ b/src/adapters/shell_adapter/adapter.py
@@ -36,7 +36,6 @@ class Adapter():
         await self.session_manager.start()
 
         self.outgoing_events_processor = Processor(self.config, self.session_manager)
-        await self._emit_event("connect")
 
         logging.info("Adapter started successfully")
 
@@ -48,7 +47,6 @@ class Adapter():
 
         while self.running:
             await asyncio.sleep(check_interval)
-            await self._emit_event("connect")
 
     async def _emit_event(self, event_type: str) -> None:
         """Emit event
@@ -72,7 +70,6 @@ class Adapter():
         if self.monitoring_task:
             self.monitoring_task.cancel()
 
-        await self._emit_event("disconnect")
         logging.info("Adapter stopped")
 
     async def process_outgoing_event(self, data: Any) -> Dict[str, Any]:

--- a/src/adapters/text_file_adapter/adapter.py
+++ b/src/adapters/text_file_adapter/adapter.py
@@ -32,7 +32,6 @@ class Adapter():
         self.file_event_cache = FileEventCache(self.config, True)
         await self.file_event_cache.start()
         self.outgoing_events_processor = Processor(self.config, self.file_event_cache)
-        await self._emit_event("connect")
 
         logging.info("Adapter started successfully")
 
@@ -44,7 +43,6 @@ class Adapter():
 
         while self.running:
             await asyncio.sleep(check_interval)
-            await self._emit_event("connect")
 
     async def _emit_event(self, event_type: str) -> None:
         """Emit event
@@ -68,7 +66,6 @@ class Adapter():
         if self.file_event_cache:
             await self.file_event_cache.stop()
 
-        await self._emit_event("disconnect")
         logging.info("Adapter stopped")
 
     async def process_outgoing_event(self, data: Any) -> Dict[str, Any]:

--- a/src/core/adapter/base_adapter.py
+++ b/src/core/adapter/base_adapter.py
@@ -63,13 +63,11 @@ class BaseAdapter(ABC):
                 self._setup_processors()
                 await self._perform_post_setup_tasks()
                 self._setup_monitoring()
-                await self._emit_event("connect")
 
                 logging.info("Adapter started successfully")
                 return
         except Exception as e:
             logging.error(f"Error starting adapter: {e}", exc_info=True)
-            await self._emit_event("disconnect")
 
         self.running = False
 
@@ -123,13 +121,11 @@ class BaseAdapter(ABC):
                     continue
 
                 self.current_reconnect_attempt = 0
-                await self._emit_event("connect")
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 logging.error(f"Error in connection monitor: {e}")
 
-                await self._emit_event("disconnect")
                 await asyncio.sleep(retry_delay)
 
     @abstractmethod
@@ -164,7 +160,6 @@ class BaseAdapter(ABC):
         await self._teardown_client()
         self.connected = False
 
-        await self._emit_event("disconnect")
         logging.info("Adapter stopped")
 
     @abstractmethod


### PR DESCRIPTION
Removes `connected` and `disconnected` event sending, as these are no longer handled by the host. 